### PR TITLE
all dependent images should get built when microbase is updated

### DIFF
--- a/genBuildImage.sh
+++ b/genBuildImage.sh
@@ -43,13 +43,24 @@ create_out_state() {
 
 main() {
   echo "JOB_TRIGGERED_BY_NAME="$JOB_TRIGGERED_BY_NAME
+  declare -a images_to_build=()
 
   IFS='_' read -ra ARR <<< "$JOB_TRIGGERED_BY_NAME"
-  export CONTEXT=${ARR[0]}
+  if [ "${ARR[0]}" == "microbase" ]; then
+    images_to_build=("api" "www" "mktg" "nexec")
+  else
+    images_to_build=("${ARR[0]}")
+  fi
 
-  set_context
-  create_image
-  create_out_state
+  for image in "${images_to_build[@]}"
+  do
+    echo "building $image"
+    export CONTEXT=$image
+
+    set_context
+    create_image
+    create_out_state
+  done
 }
 
 main

--- a/shippable.yml
+++ b/shippable.yml
@@ -567,7 +567,6 @@ jobs:
         scopes:
           - ecr
       - IN: microbase_img
-        switch: off
       - IN: mktg_repo
       - IN: nexec_repo
       - IN: api_repo


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/9622

tested with local scirpt to print correct versions

```
➜  shippable ./test.sh
JOB_TRIGGERED_BY_NAME=microbase_img
building ..api
setting context for: api
creating image
creating out state
building ..www
setting context for: www
creating image
creating out state
building ..mktg
setting context for: mktg
creating image
creating out state
building ..nexec
setting context for: nexec
creating image
creating out state
```
